### PR TITLE
fix: prevent table close on click outside

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svelte-fui/core",
-	"version": "1.0.0-alpha.14",
+	"version": "1.0.0-alpha.15",
 	"sideEffects": false,
 	"description": "An implementation of Microsoft Fluent UI v9 for Svelte framework",
 	"author": "ryu-man",

--- a/packages/core/src/lib/dropdown/dropdown-menu.svelte
+++ b/packages/core/src/lib/dropdown/dropdown-menu.svelte
@@ -90,7 +90,7 @@
 		// 	return;
 		// }
 
-		close();
+		dropdown_context?.closeMenu();
 	}
 </script>
 


### PR DESCRIPTION
fixes #44 

- close dropdown menu using the method from the context