### PR TITLE
Update Label and Field required props

### DIFF
--- a/packages/core/src/lib/field/field.svelte
+++ b/packages/core/src/lib/field/field.svelte
@@ -8,6 +8,7 @@
 	import { classnames } from '../internal';
 	import { Label } from '../label';
 
+	export let required: boolean | string = false;
 	export let label: string = '';
 	export let orientation: 'horizontal' | 'vertical' = 'vertical';
 	export let size: 'sm' | 'md' | 'lg' = 'md';
@@ -37,7 +38,7 @@
 </script>
 
 <div class={classnames('fui-field', orientation, state, size, { 'no-label': !label })}>
-	<Label>{label}</Label>
+	<Label {required}>{label}</Label>
 	<slot />
 </div>
 

--- a/packages/core/src/lib/label/label.svelte
+++ b/packages/core/src/lib/label/label.svelte
@@ -24,6 +24,9 @@
 	{...$$restProps}
 >
 	<slot />
+	{#if required !== false}
+		<span class='fui-required-label'>{required === true ? '*' : required}</span>
+	{/if}
 </label>
 
 <style lang="postcss">
@@ -33,12 +36,12 @@
 		&.disabled {
 			@apply text-neutral-foreground-disabled;
 
-			&.required {
+			& > .fui-required-label {
 				@apply text-neutral-foreground-disabled;
 			}
 		}
 
-		&.required {
+		& > .fui-required-label {
 			@apply pl-xs text-palette-red-foreground-3;
 		}
 		/* 

--- a/packages/core/src/lib/label/types.ts
+++ b/packages/core/src/lib/label/types.ts
@@ -4,7 +4,7 @@ export type LabelSize = 'sm' | 'md' | 'lg';
 
 export type LabelProps = HTMLAttributes<HTMLLabelElement> & {
 	disabled?: boolean;
-	required?: boolean;
+	required?: boolean | string;
 	size?: LabelSize;
 	class?: string;
 };


### PR DESCRIPTION
Now matches the [Fluent UI v9](https://react.fluentui.dev/?path=/docs/components-label--docs#required) spec with using an asterisk or a string if provided.

```svelte
<Field {...args} label="Required Field" state="none" required='***'>
    <Input />
    <FieldMessageInfo open>This an info message</FieldMessageInfo>
</Field>
```

![image](https://github.com/user-attachments/assets/e40991b5-1279-47a3-ba40-cc817f900863)
