### PR TITLE
chore: adjust field, input and label components

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@svelte-fui/core",
-	"version": "1.0.0-alpha.18",
+	"version": "1.0.0-alpha.19",
 	"sideEffects": false,
 	"description": "An implementation of Microsoft Fluent UI v9 for Svelte framework",
 	"author": "ryu-man",

--- a/packages/core/src/lib/context/sharedContext.ts
+++ b/packages/core/src/lib/context/sharedContext.ts
@@ -1,31 +1,30 @@
-import { getContext, hasContext, setContext } from 'svelte';
-import { type Readable, type Writable, derived, get, readonly, writable } from 'svelte/store';
+import { getContext, setContext } from 'svelte';
+import { type Readable, type Writable, writable } from 'svelte/store';
 
-export const SVELTE_FUI_SHARED_CONTEXT_KEY = 'svelte-fui-shared-context-key';
+export const SVELTE_FUI_SHARED_CONTEXT_KEY = '@fui/context/shared';
 
-export type SharedContext<T> = Record<string, Record<string, unknown>> & T;
+export type SharedContext<T> = Record<string, unknown> & T;
 
-export function getSharedContext<T>(key?: 'input' | 'label'): Readable<SharedContext<T>> {
-	const context$ = getContext(SVELTE_FUI_SHARED_CONTEXT_KEY) as Writable<SharedContext<T>>;
-
-	if (!context$) {
-		return readonly(writable({} as SharedContext<T>));
-	}
-
-	if (key) {
-		return derived(context$, (val) => val[key] as SharedContext<T>);
-	}
-
-	return readonly(context$);
+/**
+ * 
+ * @deprecated
+ */
+export function getSharedContext<T>(...segment: string[]): Readable<SharedContext<T>> {
+	return getContext(
+		[SVELTE_FUI_SHARED_CONTEXT_KEY, ...segment.filter(Boolean)].join('/')
+	) as Writable<SharedContext<T>>;
 }
 
-export function setSharedContext<T>(context: SharedContext<T>): Writable<SharedContext<T>> {
-	if (hasContext(SVELTE_FUI_SHARED_CONTEXT_KEY)) {
-		// extends and overrides the existent context
-		const existedContext = get(getSharedContext());
-
-		setContext(SVELTE_FUI_SHARED_CONTEXT_KEY, writable(structuredClone({ ...existedContext, ...context })));
-	}
-
-	return setContext(SVELTE_FUI_SHARED_CONTEXT_KEY, writable(structuredClone(context)));
+/**
+ * 
+ * @deprecated
+ */
+export function setSharedContext<T>(
+	context: SharedContext<T>,
+	...segments: string[]
+): Writable<SharedContext<T>> {
+	return setContext(
+		[SVELTE_FUI_SHARED_CONTEXT_KEY, ...segments.filter(Boolean)].join('/'),
+		writable(structuredClone(context))
+	);
 }

--- a/packages/core/src/lib/field/field.svelte
+++ b/packages/core/src/lib/field/field.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
-	import { setFieldContext } from './context';
-	import type { FieldState } from './types,';
-	import { setSharedContext } from '../context';
+	import { writable } from 'svelte/store';
+
 	import CheckmarkCircleFilled from '@svelte-fui/core/icons/checkmark-circle-filled.svelte';
 	import ErrorCircleFilled from '@svelte-fui/core/icons/error-circle-filled.svelte';
 	import WarningFilled from '@svelte-fui/core/icons/warning-filled.svelte';
-	import { classnames } from '../internal';
+
+	import { setFieldContext } from './context';
+	import type { FieldState } from './types,';
+
 	import { Label } from '../label';
+	import { classnames } from '../internal';
+	import { setSharedContext } from '../internal/context';
 
 	export let label: string = '';
 	export let orientation: 'horizontal' | 'vertical' = 'vertical';
 	export let size: 'sm' | 'md' | 'lg' = 'md';
 	export let validationMessage = '';
 	export let state: FieldState = validationMessage ? 'error' : 'none';
+	export let required = false;
 
 	const validation_message_icons = {
 		error: ErrorCircleFilled,
@@ -21,11 +26,28 @@
 		none: undefined
 	};
 
-	const sharedContext$ = setSharedContext({
-		input: { invalid: state === 'error', size },
-		label: { size }
+	const sharedInputContext$ = setSharedContext(
+		writable({
+			invalid: state === 'error',
+			size,
+			required
+		}),
+		'input'
+	);
+	$: sharedInputContext$.set({ invalid: state === 'error', size, required });
+
+	const sharedLabelContext$ = setSharedContext(
+		writable({
+			size,
+			required
+		}),
+		'label'
+	);
+
+	$: sharedLabelContext$.set({
+		size,
+		required
 	});
-	$: sharedContext$.set({ input: { invalid: state === 'error', size }, label: { size } });
 
 	const { icon$, state$ } = setFieldContext({
 		state,

--- a/packages/core/src/lib/input/index.ts
+++ b/packages/core/src/lib/input/index.ts
@@ -1,2 +1,10 @@
+// import InputElement from './input-element.svelte';
+// import InputRoot from './input-root.svelte';
+
 export { default as Input } from './input.svelte';
-export { default as InputSkin } from './input-skin.svelte';
+export { default as InputSkin } from './input-root.svelte';
+
+// export const Input = {
+//     Root: InputRoot,
+//     Element: InputElement
+// }

--- a/packages/core/src/lib/input/input-element.svelte
+++ b/packages/core/src/lib/input/input-element.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { writable, type Writable } from 'svelte/store';
+
+	import type { ExternalContext, InputType } from './types';
+
+	import { classnames } from '../internal';
+
+	import { getSharedContext } from '../internal/context';
+
+	type InputEvent = Event & {
+		currentTarget: EventTarget & HTMLInputElement;
+	};
+
+	const sharedContext$ = (getSharedContext('input') || writable({})) as Writable<
+		Partial<ExternalContext>
+	>;
+
+	/** The input's current value. */
+	export let value: any = '';
+	export let valueAsNumber: number | undefined = undefined;
+	export let valueAsDate: Date | undefined | null = undefined;
+
+	/** Determiness the input type of the textbox. */
+	export let type: InputType = 'text';
+
+	/** The initial placeholder text displayed if no value is present. */
+	export let placeholder: string | undefined = undefined;
+
+	/** Determines whether the textbox can be typed in or not. */
+	export let readonly = false;
+
+	/** Controls whether the TextBox is intended for user interaction, and styles it accordingly. */
+	export let disabled = false;
+
+	export let required = false;
+
+	export let name: string | undefined = undefined;
+
+	export let ariaLabel: string | undefined = undefined;
+
+	export let ariaDescribedby: string | undefined = undefined;
+	export let ariaInvalid = $sharedContext$.invalid || false;
+
+	/** Specifies a custom class name for the TextBox container. */
+	let klass = '';
+	export { klass as class };
+
+	export let id: string | undefined = undefined;
+
+	function setInputType(node: HTMLInputElement, type: InputType) {
+		node.type = type;
+	}
+
+	function oninput(e: InputEvent) {
+		const currentTarget = e.currentTarget as HTMLInputElement;
+		valueAsNumber = currentTarget.valueAsNumber;
+		valueAsDate = currentTarget.valueAsDate;
+	}
+</script>
+
+<input
+	use:setInputType={type}
+	class={classnames(
+		'px-xxs text-neutral-foreground-1 leading-inherit flex-1 border-none bg-transparent outline-none',
+		klass
+	)}
+	{id}
+	{name}
+	{placeholder}
+	{disabled}
+	{readonly}
+	required={$sharedContext$.required ?? required}
+	aria-label={ariaLabel}
+	aria-describedby={ariaDescribedby}
+	aria-invalid={$sharedContext$.invalid ?? ariaInvalid}
+	bind:value
+	on:input={oninput}
+	on:input
+	on:blur
+	on:keydown
+	on:keypress
+	on:keyup
+	on:click
+	{...$$restProps}
+/>

--- a/packages/core/src/lib/input/input-root.svelte
+++ b/packages/core/src/lib/input/input-root.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import { type Writable, writable } from 'svelte/store';
-	import { classnames } from '@svelte-fui/core/internal';
-	import { getSharedContext } from '@svelte-fui/core/internal/context';
-	import type { ExternalContext, InputSize, InputType } from './types';
 
-	const sharedContext$ = getSharedContext<Writable<ExternalContext>>('input') || writable({});
+	import { classnames, prefix } from '@svelte-fui/core/internal';
+
+	import type { ExternalContext, InputSize } from './types';
+
+	import { getSharedContext } from '../internal/context';
+
+	const sharedContext$ = (getSharedContext('input') || writable({})) as Writable<
+		Partial<ExternalContext>
+	>;
 
 	/** Determines whether the textbox can be typed in or not. */
 	export let readonly = false;
@@ -12,11 +17,11 @@
 	/** Controls whether the TextBox is intended for user interaction, and styles it accordingly. */
 	export let disabled = false;
 
-	export let size: InputSize = $sharedContext$.size || 'md';
+	export let size: InputSize = $sharedContext$?.size ?? 'md';
 
 	export let underline = false;
 
-	export let ariaInvalid = $sharedContext$.invalid || false;
+	export let ariaInvalid = $sharedContext$?.invalid ?? false;
 
 	/** Specifies a custom class name for the TextBox container. */
 	let klass = '';
@@ -28,10 +33,12 @@
 <button
 	class={classnames(
 		'fui-input-skin px-mNudge gap-xxs inline-flex',
-		{ size, underline, disabled, invalid: ariaInvalid && !disabled },
+		prefix($sharedContext$?.size ?? size, 'size'),
+		{ underline, disabled, invalid: ($sharedContext$?.invalid ?? ariaInvalid) && !disabled },
 		klass
 	)}
 	{id}
+	{...$$restProps}
 >
 	<slot />
 </button>

--- a/packages/core/src/lib/input/input.stories.svelte
+++ b/packages/core/src/lib/input/input.stories.svelte
@@ -9,7 +9,9 @@
 
 	const arg_types = {} satisfies ArgTypes;
 
-	const default_args: Partial<Record<keyof typeof arg_types, any>> = {};
+	const default_args: Partial<Record<keyof typeof arg_types, any>> = {
+		size: 'md'
+	};
 
 	export const meta = {
 		title: 'Components/Input',

--- a/packages/core/src/lib/input/input.svelte
+++ b/packages/core/src/lib/input/input.svelte
@@ -1,15 +1,8 @@
 <script lang="ts">
-	import { writable } from 'svelte/store';
-	import { getSharedContext } from '@svelte-fui/core/internal/context';
-	import InputSkin from './input-skin.svelte';
-	import type { ExternalContext, InputSize, InputType } from './types';
+	import InputRoot from './input-root.svelte';
+	import InputElement from './input-element.svelte';
+	import type { InputSize, InputType } from './types';
 	import { classnames } from '../internal';
-
-	type InputEvent = Event & {
-		currentTarget: EventTarget & HTMLInputElement;
-	};
-
-	const sharedContext$ = getSharedContext<ExternalContext>('input') || writable({});
 
 	/** The input's current value. */
 	export let value: any = '';
@@ -28,7 +21,9 @@
 	/** Controls whether the TextBox is intended for user interaction, and styles it accordingly. */
 	export let disabled = false;
 
-	export let size: InputSize = $sharedContext$.size || 'md';
+	export let required = false;
+
+	export let size: InputSize = 'md';
 
 	export let underline = false;
 
@@ -37,51 +32,56 @@
 	export let ariaLabel: string | undefined = undefined;
 
 	export let ariaDescribedby: string | undefined = undefined;
-	export let ariaInvalid = $sharedContext$.invalid || false;
+	export let ariaInvalid = false;
 
 	/** Specifies a custom class name for the TextBox container. */
 	let klass = '';
 	export { klass as class };
 
 	export let id: string | undefined = undefined;
-
-	function setInputType(node: HTMLInputElement, type: InputType) {
-		node.type = type;
-	}
-
-	function oninput(e: InputEvent) {
-		const currentTarget = e.currentTarget as HTMLInputElement;
-		valueAsNumber = currentTarget.valueAsNumber;
-		valueAsDate = currentTarget.valueAsDate;
-	}
 </script>
 
-<InputSkin class={classnames('fui-input', { size, underline, disabled, invalid: ariaInvalid && !disabled })} {id}>
+<InputRoot
+	class={classnames('fui-input')}
+	{size}
+	{disabled}
+	{readonly}
+	{underline}
+	{ariaInvalid}
+	{id}
+>
 	{#if $$slots.before}
 		<div class="flex h-full items-center">
 			<slot name="before" />
 		</div>
 	{/if}
 
-	<input
-		use:setInputType={type}
-		class={classnames('px-xxs text-neutral-foreground-1 leading-inherit flex-1 border-none bg-transparent', klass)}
+	<InputElement
+		class={classnames(
+			'px-xxs text-neutral-foreground-1 leading-inherit flex-1 border-none bg-transparent',
+			klass
+		)}
 		{id}
 		{name}
+		{type}
 		{placeholder}
 		{disabled}
 		{readonly}
-		aria-label={ariaLabel}
-		aria-describedby={ariaDescribedby}
-		aria-invalid={ariaInvalid}
+		{required}
+		{ariaLabel}
+		{ariaDescribedby}
+		{ariaInvalid}
 		bind:value
-		on:input={oninput}
+		bind:valueAsDate
+		bind:valueAsNumber
+		on:input
 		on:input
 		on:blur
 		on:keydown
 		on:keypress
 		on:keyup
 		on:click
+		{...$$restProps}
 	/>
 
 	{#if $$slots.after}
@@ -89,10 +89,4 @@
 			<slot name="after" />
 		</div>
 	{/if}
-</InputSkin>
-
-<style lang="postcss">
-	input {
-		@apply outline-none;
-	}
-</style>
+</InputRoot>

--- a/packages/core/src/lib/input/types.ts
+++ b/packages/core/src/lib/input/types.ts
@@ -1,6 +1,6 @@
 import type { HTMLInputTypeAttribute } from 'svelte/elements';
 
 export type InputType = HTMLInputTypeAttribute;
-export type InputSize = 'sm' | 'md' | 'lg'
+export type InputSize = 'sm' | 'md' | 'lg';
 
-export type ExternalContext = { invalid: boolean; size: InputSize }
+export type ExternalContext = { invalid: boolean; required: boolean; size: InputSize };

--- a/packages/core/src/lib/internal/context.ts
+++ b/packages/core/src/lib/internal/context.ts
@@ -13,12 +13,12 @@ export function setFluentContext<T>(context: T, id = '', ...segments: string[]) 
 	return setContext(key, context);
 }
 
-export function getSharedContext<T>(id = '', ...segments: string[]) {
-	return getFluentContext<T>('shared', id, ...segments);
+export function getSharedContext<T>(...segments: string[]) {
+	return getFluentContext<T>('shared', ...segments);
 }
 
-export function setSharedContext<T>(context: T, id = '', ...segments: string[]) {
-	return setFluentContext(context, 'shared', id, ...segments);
+export function setSharedContext<T>(context: T, ...segments: string[]) {
+	return setFluentContext(context, 'shared', ...segments);
 }
 
 export function mergeContext<T>(...contexts: (T | undefined)[]) {

--- a/packages/core/src/lib/internal/index.ts
+++ b/packages/core/src/lib/internal/index.ts
@@ -145,3 +145,23 @@ const custom_tw_merge = extendTailwindMerge({
 export function classnames(...args: ClassValue[]): string {
 	return custom_tw_merge(clsx(...args));
 }
+
+export function prefix(value?: string, prefix?: string, delimiter = '-') {
+	if (!value) return '';
+
+	if (!prefix) {
+		return value;
+	}
+
+	return `${prefix}${delimiter}${value}`;
+}
+
+export function postfix(value?: string, postfix?: string, delimiter = '-') {
+	if (!value) return '';
+
+	if (!prefix) {
+		return value;
+	}
+
+	return `${value}${delimiter}${postfix}`;
+}

--- a/packages/core/src/lib/label/label.svelte
+++ b/packages/core/src/lib/label/label.svelte
@@ -1,25 +1,42 @@
 <script lang="ts">
+	import { writable, type Writable } from 'svelte/store';
+
 	import { classnames } from '@svelte-fui/core/internal';
+
 	import type { LabelProps } from './types';
+
+	import { getSharedContext } from '../internal/context';
 
 	type $$Props = LabelProps;
 
+	type ExternalContext = {
+		size: 'sm' | 'md' | 'lg';
+		required: boolean;
+	};
+
+	const sharedContext$ = (getSharedContext('label') || writable({})) as Writable<
+		Partial<ExternalContext>
+	>;
+
 	export let disabled: $$Props['disabled'] = false;
-	export let required: $$Props['required'] = false;
-	export let size: $$Props['size'] = 'md';
+	export let required: $$Props['required'] = $sharedContext$.required ?? false;
+	export let size: $$Props['size'] = $sharedContext$.size ?? 'md';
 
 	let klass: $$Props['class'] = '';
 	export { klass as class };
+
+	$: _required = $sharedContext$.required ?? required;
+	$: _size = $sharedContext$.size ?? size;
 </script>
 
 <label
 	class={classnames(
 		'fui-label font-base',
-		{ disabled, required },
+		{ disabled, required: _required },
 		klass,
-		size === 'sm' && 'text-base-200 leading-base-200',
-		size === 'md' && 'text-base-300 leading-base-300',
-		size === 'lg' && 'text-base-400 leading-base-400 font-semibold'
+		_size === 'sm' && 'text-base-200 leading-base-200',
+		_size === 'md' && 'text-base-300 leading-base-300',
+		_size === 'lg' && 'text-base-400 leading-base-400 font-semibold'
 	)}
 	{...$$restProps}
 >


### PR DESCRIPTION
- refactor input module
- reactively read from the shared context
- add `required` prop
- add `prefix` and `postfix` methods
- inherit data from external in label
- use internal's shared context
- many more small enhancement