### PR TITLE
Fix dropdowns preventing outside elements from being clicked

### DIFF
--- a/packages/core/src/lib/dropdown/dropdown-menu.svelte
+++ b/packages/core/src/lib/dropdown/dropdown-menu.svelte
@@ -77,6 +77,7 @@
 	}
 
 	function onclick_outside(ev: CustomEvent) {
+		if(!$open_store) return;
 		ev.preventDefault();
 
 		const inner_event = ev.detail as Event;


### PR DESCRIPTION
Having a html input element and a Dropdown element on the same page would cause the input element to be unusable due to the preventDefault() call.